### PR TITLE
Potential fix for code scanning alert no. 4: Clear-text logging of sensitive information

### DIFF
--- a/azure_functions/shared_code/servicebus.py
+++ b/azure_functions/shared_code/servicebus.py
@@ -49,6 +49,6 @@ def publish_to_payment_queue(payload: Dict[str, Any]) -> None:
         with ServiceBusClient.from_connection_string(_CONNECTION, connection_timeout=2) as client:
             with client.get_queue_sender(queue_name="payment-queue") as sender:
                 sender.send_messages(ServiceBusMessage(json.dumps(payload, ensure_ascii=False)))
-                logging.info("Successfully sent list to payment queue: %s", payload.get("listId"))
+                logging.info("Successfully sent list to payment queue.")
     except Exception as e:
         logging.warning("Failed to send to payment queue (non-critical): %s", str(e))


### PR DESCRIPTION
Potential fix for [https://github.com/26zl/SparCollection/security/code-scanning/4](https://github.com/26zl/SparCollection/security/code-scanning/4)

To fix this problem, we should avoid logging potentially sensitive data (like `listId`) directly. Instead, the logs should contain non-sensitive operational data, such as the success of the operation, and possibly a sanitized or redacted reference to the list. A common practice is to log only a fixed prefix, a hash, or a truncated value, or simply to omit the identifier altogether from logs. 

Specifically, in `azure_functions/shared_code/servicebus.py`, the line
```python
logging.info("Successfully sent list to payment queue: %s", payload.get("listId"))
```
should be modified to avoid logging the raw `listId`. 

The best approach is to log only that the operation was successful, optionally indicating presence of a listId or logging a short prefix/hash if operational traceability is essential, but not the full value. For now, a simple and secure fix is to omit the identifier from the log entirely.

No new imports are necessary. The change is localized to this log statement (line 52).

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
