### PR TITLE
Potential fix for code scanning alert no. 1: Clear-text logging of sensitive information

### DIFF
--- a/azure_functions/shared_code/servicebus.py
+++ b/azure_functions/shared_code/servicebus.py
@@ -22,7 +22,7 @@ def publish_event(payload: Dict[str, Any]) -> None:
         with ServiceBusClient.from_connection_string(_CONNECTION, connection_timeout=2) as client:
             with client.get_queue_sender(queue_name=_QUEUE_NAME) as sender:
                 sender.send_messages(ServiceBusMessage(json.dumps(payload, ensure_ascii=False)))
-                logging.info("Successfully published event to Service Bus: %s", payload.get("type", "unknown"))
+                logging.info("Successfully published event to Service Bus.")
                 
                 # If this is a list-completed event, also send to payment queue
                 if payload.get("type") == "list-completed":


### PR DESCRIPTION
Potential fix for [https://github.com/26zl/SparCollection/security/code-scanning/1](https://github.com/26zl/SparCollection/security/code-scanning/1)

To fix the problem, sensitive or potentially user-controlled data should never be logged in plaintext, especially in shared event-publishing mechanisms. Here, the logging of `payload.get("type", "unknown")` gives a false sense of safety because `"type"` is currently an application-constant, but the structure could change and `"type"` could inadvertently contain user or private information. The best fix is to not log any values that are part of the user-supplied payload, but rather stick to constant or operational information only. Thus, you should change the logging statement on line 25 of `azure_functions/shared_code/servicebus.py` to avoid logging any payload content. Instead, log only a fixed message such as `"Successfully published event to Service Bus"` or optionally include the queue name to aid debugging if needed. Only lines within the provided file `azure_functions/shared_code/servicebus.py` need editing.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
