### PR TITLE
Potential fix for code scanning alert no. 2: Clear-text logging of sensitive information

### DIFF
--- a/azure_functions/shared_code/servicebus.py
+++ b/azure_functions/shared_code/servicebus.py
@@ -10,6 +10,15 @@ _QUEUE_NAME: str = os.getenv("SERVICEBUS_QUEUE_NAME", "list-updates")
 
 
 def publish_event(payload: Dict[str, Any]) -> None:
+    def _sanitize_payload_for_logging(data: Dict[str, Any]) -> Dict[str, Any]:
+        """Return a copy of the payload with sensitive fields redacted for safe logging."""
+        SENSITIVE_KEYS = {"employeeId", "completedBy"}
+        sanitized = data.copy()
+        for key in SENSITIVE_KEYS:
+            if key in sanitized:
+                sanitized[key] = "***REDACTED***"
+        return sanitized
+
     if not _CONNECTION:
         logging.info("SERVICEBUS_CONNECTION missing; skipping publish")
         return
@@ -29,12 +38,14 @@ def publish_event(payload: Dict[str, Any]) -> None:
                     publish_to_payment_queue(payload)
                     
     except ImportError:
-        logging.warning("azure-servicebus not available; logging event instead: %s", json.dumps(payload))
+        sanitized = _sanitize_payload_for_logging(payload)
+        logging.warning("azure-servicebus not available; logging event instead: %s", json.dumps(sanitized, ensure_ascii=False))
     except Exception as e:
         # Don't let Service Bus errors slow down the main operation
         logging.warning("Service Bus publish failed (non-critical): %s", str(e))
         # Just log the event instead of failing
-        logging.info("Event logged instead: %s", json.dumps(payload))
+        sanitized = _sanitize_payload_for_logging(payload)
+        logging.info("Event logged instead: %s", json.dumps(sanitized, ensure_ascii=False))
 
 
 def publish_to_payment_queue(payload: Dict[str, Any]) -> None:


### PR DESCRIPTION
Potential fix for [https://github.com/26zl/SparCollection/security/code-scanning/2](https://github.com/26zl/SparCollection/security/code-scanning/2)

To fix this issue, we must ensure that potentially sensitive fields in the payload (especially `employeeId`/`completedBy`) are not logged in clear text—either by omitting them from logs or by redacting/masking their values. The fix should, for all fallback or error logging in `publish_event`, sanitize the payload object before logging. This involves: (1) making a shallow copy of the payload, (2) replacing or removing the sensitive fields, and (3) logging the safe-to-print version (redacting any fields like "employeeId", "completedBy", etc.).

This fix is to be applied in `azure_functions/shared_code/servicebus.py` wherever `json.dumps(payload)` or similar logs may emit sensitive data. Specifically, lines 32 and 37 need updating. We'll define a small helper function within the relevant scope to produce a sanitized copy of the payload dictionary for logging, and use that in both locations.

No new dependencies are strictly needed—basic Python libraries (copy, etc.) suffice.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
